### PR TITLE
Update `peerDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nexered",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nexered",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "yargs": "^17.4.1"
@@ -25,9 +25,9 @@
         "typescript": "^4.6.3"
       },
       "peerDependencies": {
-        "next": "^12",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0"
+        "next": "^12 || ^13",
+        "react": ">17.0.2",
+        "react-dom": ">17.0.2"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "typescript": "^4.6.3"
   },
   "peerDependencies": {
-    "next": "^12",
-    "react": "^17.0.2 || ^18.0.0-0",
-    "react-dom": "^17.0.2 || ^18.0.0-0"
+    "next": "^12 || ^13",
+    "react": ">17.0.2",
+    "react-dom": ">17.0.2"
   },
   "dependencies": {
     "yargs": "^17.4.1"


### PR DESCRIPTION
There have been no changes to the redirects function syntax in Next.js 13, so I think it should be supported. In fact, there is reason to believe that it's been this way [since at least v11.0.0](https://github.com/vercel/next.js/blob/v11.0.0/docs/api-reference/next.config.js/redirects.md) and possibly even before that.

There also doesn't seem to be any reason for `react` and `react-dom` to be peer dependencies, so they should probably be removed.

Optionally, you may also want to version bump.